### PR TITLE
Alias_method_chain was replaced due to it was deprecated in rails 5.1

### DIFF
--- a/lib/link_to_active_state/view_helpers/url_helper.rb
+++ b/lib/link_to_active_state/view_helpers/url_helper.rb
@@ -5,7 +5,8 @@ module LinkToActiveState
   module ViewHelpers
     module UrlHelper
       def self.included(base)
-        base.send(:alias_method_chain, :link_to, :active_state)
+        base.send(:alias_method, :link_to_without_active_state, :link_to)
+        base.send(:alias_method, :link_to, :link_to_with_active_state)
       end
 
       def link_to_with_active_state(*args, &block)


### PR DESCRIPTION
Replaced alias_method_chain with alias_method, because alias_method_chain was deprecated in rails 5.1